### PR TITLE
Disable PROGMEM for Electron

### DIFF
--- a/firmware/fix_fft.h
+++ b/firmware/fix_fft.h
@@ -4,6 +4,10 @@
 #include "application.h"
 #include <math.h>
 
+#define PROGMEM
+#define prog_uint16_t   uint16_t
+#define pgm_read_word_near(x)   ((uint16_t)*(x))
+
 //#define pgm_read_byte_near(_addr) (pgm_read_byte(_addr))
 //#define pgm_read_byte_far(_addr)	(pgm_read_byte(_addr))
 //#define pgm_read_word(_addr) (*(const uint16_t *)(_addr))

--- a/spark.json
+++ b/spark.json
@@ -1,5 +1,5 @@
 {
-	"name": "RGBPixelClockZ",
+	"name": "RGBPixelClock",
 	"author": "Paul Kourany @peekay123",
 	"version": "1.1.2",
 	"license": "MIT license",

--- a/spark.json
+++ b/spark.json
@@ -1,7 +1,7 @@
 {
-	"name": "RGBPixelClock",
+	"name": "RGBPixelClockZ",
 	"author": "Paul Kourany @peekay123",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"license": "MIT license",
 	"description": "RGBPongClock for RGB Pixel Clock Kit"
 }


### PR DESCRIPTION
I used this to get the RGBPixelClock to build and run on my shiny new Electron. It wasn't finding a definition for pgm_read_word_near so I used this to define PROGMEM away since I seem to enough RAM on Electron. I bumped the version so I could import it into the IDE.

My feelings won't be hurt if you don't take my change. ;)
